### PR TITLE
ON profile log out and log in, datablock was not being destroyed, and…

### DIFF
--- a/source/DataBlock.py
+++ b/source/DataBlock.py
@@ -37,9 +37,11 @@ class DataBlock:
             self.listener = remoteUpdate.RemoteUpdate()
             self.lock = threading.Lock()
             self.size = self.getLen()
-            self.updaterThread = threading.Thread(target = self.updater, args=())
+            self.updaterThread = threading.Thread(target = self.updater, name='UpdaterThread')
+            self.listenerThread = threading.Thread(target=self.listener.start, name='UpdateListener')
             self.cv = threading.Condition()
 
+            self.listenerThread.start()
             self.updaterThread.start()
 
     def __del__(self):
@@ -89,6 +91,53 @@ class DataBlock:
         print('\nDumping Comments')
         debug_ObjectdumpList(self.comments)
 
+    def updater(self):
+        logging.info('Updater Thread %s started' % threading.get_ident())
+        if self.firstLoad:
+            self.updateAllObjects()
+            self.firstLoad = False
+
+        while self.alive:
+            time.sleep(1)
+            if self.listener.isDBChanged:
+                #time.sleep(2)   # <<--- This is the thread timing tweak.
+                # with self.cv:
+                #     self.cv.wait_for(self.updateAllObjects)
+                self.lock.acquire()
+                self.updateAllObjects()
+                self.lock.release()
+                self.lock.acquire()
+                self.executeUpdaterCallbacks()
+                self.lock.release()
+                self.lock.acquire()
+                self.listener.isDBChanged = False
+                self.lock.release()
+
+    def turnOffListener(self):
+        self.alive = False
+    def turnOnListener(self):
+        self.alive = True
+
+    def packCallback(self,callback):
+        logging.info('Packing Callback %s' % str(callback))
+        self.updaterCallbacks.append(callback)
+
+    def executeUpdaterCallbacks(self):
+        if len(self.updaterCallbacks) > 0:
+            for func in self.updaterCallbacks:
+                logging.info('Thread %s Executing Updater Func %s' % ( threading.get_ident(), str(func) ) )
+                print('There are %i active threads'%threading.active_count())
+
+                try:
+                    func()
+                except Exception as e:
+                    logging.exception('Excepition is funciton %s\n'%str(func),str(e))
+
+    def shutdown(self):
+        logging.info('Shutting down Thread %s'%threading.get_ident())
+        self.alive = False
+        if self.mode != 'test':
+            self.listener.stop()
 
 
 
@@ -412,45 +461,3 @@ class DataBlock:
         self.conn.setData(CardQuery.deleteEpic(item))
 
 
-    def populateSubItems(self,item,epicMap):
-       pass
-
-
-    def updater(self):
-        logging.info('Updater Thread %s started' % threading.get_ident())
-        threading.Thread(target=self.listener.start,args=()).start()
-        if self.firstLoad:
-            self.updateAllObjects()
-            self.firstLoad = False
-
-        while self.alive:
-            time.sleep(1)
-            if self.listener.isDBChanged:
-                time.sleep(2)   # <<--- This is the thread timing tweak.
-                with self.cv:
-                    self.cv.wait_for(self.updateAllObjects)
-
-                    self.executeUpdaterCallbacks()
-                    self.listener.isDBChanged = False
-
-
-    def turnOffListener(self):
-        self.alive = False
-    def turnOnListener(self):
-        self.alive = True
-
-    def packCallback(self,callback):
-        logging.info('Packing Callback %s' % str(callback))
-        self.updaterCallbacks.append(callback)
-
-    def executeUpdaterCallbacks(self):
-        if len(self.updaterCallbacks) > 0:
-            for func in self.updaterCallbacks:
-                logging.info('Thread %s Executing Updater Func %s' % ( threading.get_ident(), str(func) ) )
-                func()
-
-    def shutdown(self):
-        logging.info('Shutting down Thread %s'%threading.get_ident())
-        self.alive = False
-        if self.mode != 'test':
-            self.listener.stop()

--- a/source/Scrumbles.py
+++ b/source/Scrumbles.py
@@ -4,7 +4,7 @@ import ctypes
 import sys
 
 
-logging.basicConfig(format='%(levelname)s:  %(asctime)s:  %(message)s', filename='Scrumbles.log',level=logging.DEBUG)
+logging.basicConfig(format='%(levelname)s:  %(asctime)s: %(threadName)s > %(message)s', filename='Scrumbles.log',level=logging.DEBUG)
 logging.info('Application starting')
 
 

--- a/source/mainView.py
+++ b/source/mainView.py
@@ -421,7 +421,10 @@ class mainView(tk.Frame):
         self.sprints = [sprint for sprint in self.controller.activeProject.listOfAssignedSprints]
         self.sprintList.importSprintsList(self.sprints)
         self.fullBacklog.importItemList(self.fullList)
-        self.fullBacklog.colorCodeListboxes()
+        try:
+            self.fullBacklog.colorCodeListboxes()
+        except Exception as e:
+            logging.exception('Error coloring list boxes',str(e))
         if (self.selectedSprint != None):
             for sprint in self.controller.activeProject.listOfAssignedSprints:
                 if (sprint.sprintName == self.selectedSprint.sprintName):

--- a/source/masterView.py
+++ b/source/masterView.py
@@ -12,7 +12,7 @@ import platform
 import webbrowser
 import DataBlock
 import Dialogs
-
+import time
 
 class masterView(tk.Tk):
     def __init__(self):
@@ -286,6 +286,10 @@ class masterView(tk.Tk):
 
 def logOut(controller):
     logging.info('%s logged out'%controller.activeUser.userID)
+    controller.dataBlock.shutdown()
+    messagebox.showinfo('Logout','Shutting Down Active Threads')
+    time.sleep(3)
+    del controller.dataBlock
     #Do Some Stuff Here To Clear States
     loginFrame = loginView.loginView(controller.container, controller)
     controller.add_frame(loginFrame, loginView)

--- a/source/remoteUpdate.py
+++ b/source/remoteUpdate.py
@@ -8,6 +8,7 @@ import logging,socket, time, threading
 
 #to test, execute this script and then make some change to the database
 
+
 class RemoteUpdate:
     def __init__(self):
         self.TCP_IP = '173.230.136.241'
@@ -18,14 +19,20 @@ class RemoteUpdate:
 
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.conn = None
-        self.keepAliveThread = threading.Thread(target = self.keepAlive, args=())
+        self.keepAliveThread = threading.Thread(target=self.kickstartKeepAlive, name='KeepConnAlive')
+        self.lock = threading.Lock()
         self.alive = True
 
-    def __del__(self):
 
+    def __del__(self):
         self.stop()
+
+    def kickstartKeepAlive(self):
+        logging.info('Starting up keep alive')
+        self.keepAlive()
+
     def keepAlive(self):
-        logging.info('Socket keep alive thread %s started'%threading.get_ident())
+
         while self.alive:
             try:
                 self.socket.send(self.MSG)
@@ -43,13 +50,16 @@ class RemoteUpdate:
             data = self.socket.recv(self.BUFF)
             
             if data == b'CHANGE':
+                self.lock.acquire()
                 self.isDBChanged = True
+                self.lock.release()
                 logging.info('Received Message from DB Server: %s' % data.decode() )
         except:
-            logging.exception('Failed to connect to remote server')
+            logging.error('disconnected from host')
             self.socket.close()
             return False
         return True
+
     def start(self):
         logging.info('Socket thread %s started' % threading.get_ident())
         logging.info('Connecting to %s on port %s' % (self.TCP_IP,self.TCP_PORT))
@@ -66,4 +76,3 @@ class RemoteUpdate:
     def stop(self):
         self.alive = False
         self.socket.close()
-


### PR DESCRIPTION
… the login process creates a new instance of datablock multiplying the number of running threads and orphaning others. This update places locks on every change a thread can make and destroys datablock during the logout process.

Signed-off-by: fallinbryan <fallinbryan@ufl.edu>

BUGFIX  #256 
BUGFIX  #259