### PR TITLE
Could not delete sprint because Sprint had same name as a project. Th…

### DIFF
--- a/source/frames/SPopMenu.py
+++ b/source/frames/SPopMenu.py
@@ -39,7 +39,8 @@ class GenericPopupMenu(Tk.Menu):
         if self.selectedObject is None:
             raise Exception('PopMenu Selected Item is None')
         else:
-            return self.findSelectedObject(self.selectedObject)
+            obj = self.findSelectedObject(self.selectedObject)
+            return obj
 
     def findSelectedObject(self,name):
         for I in self.dataBlock.items:

--- a/source/views/masterView.py
+++ b/source/views/masterView.py
@@ -349,7 +349,10 @@ def logOut(controller):
     controller.title("Scrumbles")
 
 def exitProgram(mainWindow):
-    setProjectFile(mainWindow.activeProject)
+    try:
+        setProjectFile(mainWindow.activeProject)
+    except:
+        pass
     setGeometryFile(mainWindow)
     plt.close('all')
     try:


### PR DESCRIPTION
…is happened because right click from Listbox gets string, function that returns object searches for objects in the database by name.  The commit Creates a validate function that forces every object name to be unique in the database to prevent this type of bug from occuring again.  This also fixes a glitch where an exeception is thrown when attempting to exit from the Login screen on first load.  wrapped the set project function is a try except pass