### PR TITLE
Analytic update patch

### DIFF
--- a/source/views/analyticsView.py
+++ b/source/views/analyticsView.py
@@ -75,7 +75,7 @@ class analyticsView(tk.Frame):
         self.selectionNotebook.enable_traversal() #Allows tabbing through ctrl+tab if notebook tabs are selected
         self.selectionNotebook.pack(fill=tk.BOTH, expand=True)
         self.updateFrame()
-        #self.controller.dataBlock.packCallback(self.updateFrame) # plt.close calls a tk.destroy which is not allowed outside of main thread
+
 
     def updateFrame(self):
         plt.close('all')

--- a/source/views/analyticsView.py
+++ b/source/views/analyticsView.py
@@ -23,6 +23,9 @@ class analyticsView(tk.Frame):
         self.eventHandler.setEventToHandle(self.listboxEvents)
 
         self.selectionNotebook = ttk.Notebook(self)
+        self.refreshButton = ttk.Button(self.selectionNotebook,text='Refresh',command=self.updateFrame)
+        self.refreshButton.pack(anchor=tk.E)
+
 
         self.sprintAnalyticsFrame = tk.Frame(self)
 
@@ -72,7 +75,7 @@ class analyticsView(tk.Frame):
         self.selectionNotebook.enable_traversal() #Allows tabbing through ctrl+tab if notebook tabs are selected
         self.selectionNotebook.pack(fill=tk.BOTH, expand=True)
         self.updateFrame()
-        self.controller.dataBlock.packCallback(self.updateFrame)
+        #self.controller.dataBlock.packCallback(self.updateFrame) # plt.close calls a tk.destroy which is not allowed outside of main thread
 
     def updateFrame(self):
         plt.close('all')


### PR DESCRIPTION
Patch removes AnalyticView update from dataBlock callbacks and attaches the function to a button in the tab bar labeled refresh.

This resolves exceptions that a raised when tk.destroy methods are called outside of the main thread